### PR TITLE
Fix some issues with displaying attribution text, and support leaflet 0.7.x

### DIFF
--- a/leaflet-tilelayer-here.js
+++ b/leaflet-tilelayer-here.js
@@ -107,11 +107,19 @@ L.TileLayer.HERE = L.TileLayer.extend({
 	},
 
 	onRemove: function onRemove(map) {
-		L.TileLayer.prototype.onRemove.call(this, map);
-
+		//
+		// Remove the attribution text, and clear the cached text so it will be recalculated
+		// if/when we are shown again.
+		//
 		this._map.attributionControl.removeAttribution(this._attributionText);
+		this._attributionText = '';
 
 		this._map.off('moveend zoomend resetview', this._findCopyrightBBox, this);
+
+		//
+		// Call the prototype last, once we've tidied up our own changes
+		//
+		L.TileLayer.prototype.onRemove.call(this, map);
 	},
 
 	_fetchAttributionBBoxes: function _onMapMove() {
@@ -152,19 +160,19 @@ L.TileLayer.HERE = L.TileLayer.extend({
 		var visibleBounds = this._map.getBounds();
 
 		for (var i=0; i<providers.length; i++) {
-			if (providers[i].minLevel < zoom && providers[i].maxLevel > zoom)
+			if (providers[i].minLevel <= zoom && providers[i].maxLevel >= zoom) {
 
-			if (!providers[i].boxes) {
-				// No boxes = attribution always visible
-				visibleProviders.push(providers[i]);
-				break;
-			}
-
-			for (var j=0; j<providers[i].boxes.length; j++) {
-				var box = providers[i].boxes[j];
-				if (visibleBounds.overlaps(box)) {
+				if (!providers[i].boxes) {
+					// No boxes = attribution always visible
 					visibleProviders.push(providers[i]);
-					break;
+				} else {
+					for (var j=0; j<providers[i].boxes.length; j++) {
+						var box = providers[i].boxes[j];
+						if (visibleBounds.intersects(box)) {
+							visibleProviders.push(providers[i]);
+							break;
+						}
+					}
 				}
 			}
 		}

--- a/leaflet-tilelayer-here.js
+++ b/leaflet-tilelayer-here.js
@@ -177,7 +177,7 @@ L.TileLayer.HERE = L.TileLayer.extend({
 			}
 		}
 
-		var attributions = ['<a href="https://legal.here.com/terms/serviceterms/gb/">HERE maps</a>'];
+		var attributions = ['<a href="https://legal.here.com/en-gb/terms" target="_blank" rel="noopener noreferrer">HERE maps</a>'];
 		for (var i=0; i<visibleProviders.length; i++) {
 			var provider = visibleProviders[i];
 			attributions.push('<abbr title="' + provider.alt + '">' + provider.label + '</abbr>');


### PR DESCRIPTION
Fix a few issues with attributions, and make compatible with 0.7.x

This PR fixes a few issues:
* onRemove() would throw an exception because `this._map` is `null`
  * fix by moving the call to the TileLayer prototype last rather than
    first, as that is what clears `_map`.
* attribution text would disappear if a layer was hidden then shown again
  * fix by clearing the cached `_attributionText` when we call
    `removeAttribution()` in `onRemove()`. This causes the attribution
    to be added again next time the layer is shown.
* the correct attribution text would not appear at the boundary levels
  * fix the comparison of zoom level to be inclusive, not exclusive
* Any provider with no boxes would skip the rest of the providers
  * don't break when no boxes are found
* attribution testing was using `LatLngBounds.overlaps()` which doesn't
  exist in 0.7.x
  * fix by using `.intersects()` instead.  In any case, `.intersects()`
    is more correct because it returns true if even a single pixel overlap
    exists, and we should attribute that pixel.
* _terms_ link for HERE.com was wrong
  * fix by updating with the latest path
  * Also make the link open in a new window as it's just to provide further information.  
  * Note the use of `rel="noopener noreferrer"` for security as described on [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target).